### PR TITLE
Update wayland.sh

### DIFF
--- a/etc/profile.d/wayland.sh
+++ b/etc/profile.d/wayland.sh
@@ -39,6 +39,9 @@ kvm)
 oracle)
   export WLR_NO_HARDWARE_CURSORS=1
   ;;
+vmware)
+  export WLR_NO_HARDWARE_CURSORS=1
+  ;;
 esac
 
 # Apply Nvidia-specific variables


### PR DESCRIPTION
Added VMware environment for hardware cursor to detect-virt part. This will fix the mouse problem in VMware Player/Workstation.

Tested for Sway with ArcoLinuxB and ArcoLinuxD on different laptops in VMware Player and VMware Workstation. W/o this setting, mouse and graphics run in different TTYs and aren't synched. With this setting ArcoLinux and Sway run smoothly in the virtual machine.